### PR TITLE
Fix new recording crash

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -297,7 +297,13 @@ class ScribeApp(QWidget):
         self.init_main_ui()
 
     def init_main_ui(self):
-        layout = QVBoxLayout()
+        """(Re)initialize the main recording UI."""
+        layout = self.layout()
+        if layout is None:
+            layout = QVBoxLayout()
+            self.setLayout(layout)
+        else:
+            self.clear_layout(layout)
 
         # Title
         title = QLabel("📸 Local Scribe Recorder")
@@ -332,8 +338,6 @@ class ScribeApp(QWidget):
         settings_button = QPushButton("⚙️ Settings")
         settings_button.clicked.connect(self.show_settings)
         layout.addWidget(settings_button)
-
-        self.setLayout(layout)
 
 
 
@@ -670,13 +674,7 @@ class ScribeApp(QWidget):
             self.capture_thread.stop()
             self.capture_thread = None
 
-        # Detach and delete existing layout so we can reinitialize UI
-        old_layout = self.layout()
-        if old_layout:
-            old_layout.setParent(None)
-            old_layout.deleteLater()
-
-        # Restore main UI
+        # Restore main UI using the existing layout
         self.setWindowTitle("Local Scribe Tool")
         self.resize(400, 200)
         self.init_main_ui()


### PR DESCRIPTION
## Summary
- keep the window layout and clear it when returning to the main screen
- allow `init_main_ui` to rebuild on an existing layout

## Testing
- `python -m py_compile gui.py`
- `python -m py_compile export.py project_io.py utils/image_tools.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_685ff3e861b08327bbdc8d5ad14a4b18