### PR TITLE
Fix layout reset for new recording

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -674,10 +674,11 @@ class ScribeApp(QWidget):
             self.capture_thread.stop()
             self.capture_thread = None
 
-        # Restore main UI using the existing layout
+        # Restore main UI
         self.setWindowTitle("Local Scribe Tool")
-        self.resize(400, 200)
+        # Clear the editor layout before resizing to avoid geometry warnings
         self.init_main_ui()
+        self.resize(400, 200)
 
     def show_settings(self):
         """Show settings dialog"""


### PR DESCRIPTION
## Summary
- clear the editor layout before resizing the window on new recording
- resize after layout reset to avoid geometry warnings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ff812e53c8327a68ee164ee25d81b