### PR TITLE
Fix layout reset for new recording

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -674,10 +674,17 @@ class ScribeApp(QWidget):
             self.capture_thread.stop()
             self.capture_thread = None
 
-        # Restore main UI using the existing layout
+        # Restore main UI
         self.setWindowTitle("Local Scribe Tool")
-        self.resize(400, 200)
+
+        # Recreate the main layout before resizing so the window's minimum
+        # size hint is accurate
         self.init_main_ui()
+
+        # Resize to at least the minimum recommended dimensions to avoid
+        # geometry warnings on some platforms
+        hint = self.minimumSizeHint()
+        self.resize(max(400, hint.width()), max(200, hint.height()))
 
     def show_settings(self):
         """Show settings dialog"""


### PR DESCRIPTION
## Summary
- clear screenshots and recreate main layout when starting a new recording
- resize window no smaller than the minimum size hint to prevent geometry warnings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ff812e53c8327a68ee164ee25d81b