### PR TITLE
Fix GUI resize issue after starting new recording

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -689,9 +689,10 @@ class ScribeApp(QWidget):
 
         # Restore main UI
         self.setWindowTitle("Local Scribe Tool")
-        # Clear the editor layout before resizing to avoid geometry warnings
+        # Clear the editor layout and rebuild the main view
         self.init_main_ui()
-        self.resize(400, 200)
+        # Let Qt determine the appropriate size based on the new layout
+        self.adjustSize()
 
     def show_settings(self):
         """Show settings dialog"""


### PR DESCRIPTION
## Summary
- avoid setting a fixed window height when starting a new recording
- let Qt resize the window based on the rebuilt layout

## Testing
- `python -m py_compile gui.py export.py project_io.py`

------
https://chatgpt.com/codex/tasks/task_e_68604246e1ac8327a8ce168455164ff7