### PR TITLE
Enable 2 screenshots per PDF page

### DIFF
--- a/export.py
+++ b/export.py
@@ -14,64 +14,63 @@ ALERT_PDF_COLORS = {
     "Tip": (117, 117, 117)       # Grey
 }
 
-def export_to_pdf(steps, output_path):
-    pdf = FPDF()
-    pdf.add_page()
-    pdf.set_font("Arial", "B", 16)
-    pdf.set_auto_page_break(True, margin=15)
 
-    page_w = pdf.w - pdf.l_margin - pdf.r_margin
-    for step in steps:
-        pdf.cell(0, 10, step["title"], ln=True)
-        pdf.ln(5)
-        if os.path.exists(step["filename"]):
-            pdf.image(step["filename"], x=pdf.l_margin, w=page_w)
-            pdf.ln(5)
+def export_to_pdf(steps, output_path):
+    """Export the recorded steps to a PDF with two screenshots per page."""
     try:
         pdf = FPDF()
         pdf.set_auto_page_break(auto=True, margin=15)
 
-        for i, step in enumerate(steps):
+        # Process steps two at a time so each page contains up to two screenshots
+        for page_start in range(0, len(steps), 2):
             pdf.add_page()
-            
-            # Add title
-            pdf.set_font("Arial", "B", 16)
-            title = step.get("title", f"Step {i+1}")
-            pdf.cell(0, 10, title, ln=True)
-            pdf.ln(5)
-            
-            # Add alerts above image
-            for alert in step.get("alerts_above", []):
-                pdf.set_font("Arial", "B", 12)
-                alert_type = alert['type']
-                color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
-                pdf.set_fill_color(color[0], color[1], color[2])
-                pdf.set_text_color(255, 255, 255)  # White text
-                if alert_type == "Warning":
-                    pdf.set_text_color(0, 0, 0)  # Black text for yellow background
-                pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
-                pdf.set_text_color(0, 0, 0)  # Reset to black
-                pdf.ln(2)
-            
-            # Add image if it exists
-            if os.path.exists(step["filename"]):
-                # Calculate image size to fit page
-                img_width = 180  # Max width for A4
-                pdf.image(step["filename"], x=15, w=img_width)
-                pdf.ln(img_width * 0.75)  # Approximate height
-            
-            # Add alerts below image
-            for alert in step.get("alerts_below", []):
-                pdf.set_font("Arial", "B", 12)
-                alert_type = alert['type']
-                color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
-                pdf.set_fill_color(color[0], color[1], color[2])
-                pdf.set_text_color(255, 255, 255)  # White text
-                if alert_type == "Warning":
-                    pdf.set_text_color(0, 0, 0)  # Black text for yellow background
-                pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
-                pdf.set_text_color(0, 0, 0)  # Reset to black
-                pdf.ln(2)
+
+            # Add up to two steps on the current page
+            for offset in range(2):
+                idx = page_start + offset
+                if idx >= len(steps):
+                    break
+                step = steps[idx]
+
+                # Add title
+                pdf.set_font("Arial", "B", 16)
+                title = step.get("title", f"Step {idx + 1}")
+                pdf.cell(0, 10, title, ln=True)
+                pdf.ln(5)
+
+                # Add alerts above image
+                for alert in step.get("alerts_above", []):
+                    pdf.set_font("Arial", "B", 12)
+                    alert_type = alert['type']
+                    color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
+                    pdf.set_fill_color(color[0], color[1], color[2])
+                    pdf.set_text_color(255, 255, 255)
+                    if alert_type == "Warning":
+                        pdf.set_text_color(0, 0, 0)
+                    pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
+                    pdf.set_text_color(0, 0, 0)
+                    pdf.ln(2)
+
+                # Add image if it exists
+                if os.path.exists(step["filename"]):
+                    img_width = 180  # Max width for A4
+                    pdf.image(step["filename"], x=15, w=img_width)
+                    pdf.ln(img_width * 0.75)
+
+                # Add alerts below image
+                for alert in step.get("alerts_below", []):
+                    pdf.set_font("Arial", "B", 12)
+                    alert_type = alert['type']
+                    color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
+                    pdf.set_fill_color(color[0], color[1], color[2])
+                    pdf.set_text_color(255, 255, 255)
+                    if alert_type == "Warning":
+                        pdf.set_text_color(0, 0, 0)
+                    pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
+                    pdf.set_text_color(0, 0, 0)
+                    pdf.ln(2)
+
+                pdf.ln(5)
 
         pdf.output(output_path)
         print(f"PDF exported to {output_path}")


### PR DESCRIPTION
## Summary
- update export logic to place two screenshots per PDF page

## Testing
- `python3 -m py_compile *.py utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686042833d388327be626be2dac9d0f4