### PR TITLE
Improve PDF export layout

### DIFF
--- a/export.py
+++ b/export.py
@@ -19,58 +19,88 @@ def export_to_pdf(steps, output_path):
     """Export the recorded steps to a PDF with two screenshots per page."""
     try:
         pdf = FPDF()
-        pdf.set_auto_page_break(auto=True, margin=15)
+        margin = 15
+        # Disable automatic page breaks so we can control exactly two screenshots per page
+        pdf.set_auto_page_break(auto=False, margin=margin)
+        pdf.set_margins(margin, margin, margin)
+
+        page_width = pdf.w - 2 * margin
+        page_height = pdf.h - 2 * margin
+
+        def text_height(step):
+            """Return the vertical space used by the title and alerts for a step."""
+            height = 10  # title height
+            height += 5  # spacing after title
+            height += len(step.get("alerts_above", [])) * (8 + 2)
+            height += len(step.get("alerts_below", [])) * (8 + 2)
+            height += 5  # spacing after the step block
+            return height
+
+        def add_step(step, idx, max_image_height):
+            """Render a single step using the provided maximum image height."""
+            pdf.set_font("Arial", "B", 16)
+            title = step.get("title", f"Step {idx + 1}")
+            pdf.cell(0, 10, title, ln=True)
+            pdf.ln(5)
+
+            for alert in step.get("alerts_above", []):
+                pdf.set_font("Arial", "B", 12)
+                alert_type = alert['type']
+                color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
+                pdf.set_fill_color(color[0], color[1], color[2])
+                pdf.set_text_color(255, 255, 255)
+                if alert_type == "Warning":
+                    pdf.set_text_color(0, 0, 0)
+                pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
+                pdf.set_text_color(0, 0, 0)
+                pdf.ln(2)
+
+            if os.path.exists(step["filename"]):
+                with Image.open(step["filename"]) as img:
+                    orig_w, orig_h = img.size
+                scale = page_width / orig_w
+                if max_image_height > 0:
+                    scale = min(scale, max_image_height / orig_h)
+                img_w = orig_w * scale
+                img_h = orig_h * scale
+                pdf.image(step["filename"], x=margin, w=img_w, h=img_h)
+                pdf.ln(img_h)
+
+            for alert in step.get("alerts_below", []):
+                pdf.set_font("Arial", "B", 12)
+                alert_type = alert['type']
+                color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
+                pdf.set_fill_color(color[0], color[1], color[2])
+                pdf.set_text_color(255, 255, 255)
+                if alert_type == "Warning":
+                    pdf.set_text_color(0, 0, 0)
+                pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
+                pdf.set_text_color(0, 0, 0)
+                pdf.ln(2)
+
+            pdf.ln(5)
 
         # Process steps two at a time so each page contains up to two screenshots
-        for page_start in range(0, len(steps), 2):
+        i = 0
+        while i < len(steps):
             pdf.add_page()
 
-            # Add up to two steps on the current page
-            for offset in range(2):
-                idx = page_start + offset
-                if idx >= len(steps):
-                    break
-                step = steps[idx]
+            step = steps[i]
+            max_height = max((page_height / 2) - text_height(step), 0)
+            add_step(step, i, max_height)
+            i += 1
 
-                # Add title
-                pdf.set_font("Arial", "B", 16)
-                title = step.get("title", f"Step {idx + 1}")
-                pdf.cell(0, 10, title, ln=True)
-                pdf.ln(5)
+            if i >= len(steps):
+                break
 
-                # Add alerts above image
-                for alert in step.get("alerts_above", []):
-                    pdf.set_font("Arial", "B", 12)
-                    alert_type = alert['type']
-                    color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
-                    pdf.set_fill_color(color[0], color[1], color[2])
-                    pdf.set_text_color(255, 255, 255)
-                    if alert_type == "Warning":
-                        pdf.set_text_color(0, 0, 0)
-                    pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
-                    pdf.set_text_color(0, 0, 0)
-                    pdf.ln(2)
-
-                # Add image if it exists
-                if os.path.exists(step["filename"]):
-                    img_width = 180  # Max width for A4
-                    pdf.image(step["filename"], x=15, w=img_width)
-                    pdf.ln(img_width * 0.75)
-
-                # Add alerts below image
-                for alert in step.get("alerts_below", []):
-                    pdf.set_font("Arial", "B", 12)
-                    alert_type = alert['type']
-                    color = ALERT_PDF_COLORS.get(alert_type, (128, 128, 128))
-                    pdf.set_fill_color(color[0], color[1], color[2])
-                    pdf.set_text_color(255, 255, 255)
-                    if alert_type == "Warning":
-                        pdf.set_text_color(0, 0, 0)
-                    pdf.cell(0, 8, f"{alert['type']}: {alert['text']}", ln=True, fill=True)
-                    pdf.set_text_color(0, 0, 0)
-                    pdf.ln(2)
-
-                pdf.ln(5)
+            step = steps[i]
+            remaining = page_height - (pdf.get_y() - margin)
+            max_height = remaining - text_height(step)
+            if max_height < 0:
+                pdf.add_page()
+                max_height = max((page_height / 2) - text_height(step), 0)
+            add_step(step, i, max_height)
+            i += 1
 
         pdf.output(output_path)
         print(f"PDF exported to {output_path}")


### PR DESCRIPTION
## Summary
- compute dynamic text height so alerts don't overlap
- only place second screenshot if remaining space is sufficient
- add helper to render steps with calculated image size

## Testing
- `python -m py_compile export.py gui/main_window.py recorder.py project_io.py settings.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_686052bfe75c8327a995c323b1e8b656